### PR TITLE
test(notifications): D3-08b email Resend + WhatsApp urgent delivery tests

### DIFF
--- a/src/__tests__/notification-email.test.ts
+++ b/src/__tests__/notification-email.test.ts
@@ -1,0 +1,139 @@
+/**
+ * Tests for Email Notification Delivery Channel (D3-08b)
+ *
+ * Tests:
+ * 1. sendEmailNotification — calls Resend API with correct to/subject/html, returns messageId
+ * 2. sendEmailNotification — handles Resend API error gracefully (no throw, logs error)
+ * 3. Email template renders correct HTML with notification data (title, body, actionUrl)
+ * 4. Rate limiting: does not send duplicate email for same notification within 5min window
+ */
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+// ---------------------------------------------------------------------------
+// Mocks
+// ---------------------------------------------------------------------------
+
+const mockResendEmailsSend = vi.fn();
+
+vi.mock("resend", () => ({
+  Resend: vi.fn().mockImplementation(() => ({
+    emails: {
+      send: mockResendEmailsSend,
+    },
+  })),
+}));
+
+const mockPrismaNotificationOutboxFindFirst = vi.fn();
+const mockPrismaNotificationOutboxUpdate = vi.fn();
+
+vi.mock("@/lib/prisma", () => ({
+  prisma: {
+    notificationOutbox: {
+      findFirst: mockPrismaNotificationOutboxFindFirst,
+      update: mockPrismaNotificationOutboxUpdate,
+    },
+  },
+}));
+
+vi.mock("@/lib/logger", () => ({
+  logger: {
+    error: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+  },
+}));
+
+vi.mock("@/lib/auth", () => ({
+  auth: vi.fn().mockResolvedValue(null),
+}));
+
+// ---------------------------------------------------------------------------
+// Import after mocks are hoisted
+// ---------------------------------------------------------------------------
+
+import { sendEmailNotification, renderEmailTemplate } from "@/lib/notification-channels";
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+const baseNotification = {
+  id: "notif-001",
+  title: "Nova mensagem recebida",
+  body: "Tens uma nova mensagem de João Silva.",
+  actionUrl: "https://app.useritmo.pt/notifications/notif-001",
+  recipientEmail: "user@example.com",
+  organizationId: "org-abc",
+};
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("sendEmailNotification", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockResendEmailsSend.mockResolvedValue({ data: { id: "resend-msg-123" }, error: null });
+    mockPrismaNotificationOutboxFindFirst.mockResolvedValue(null);
+  });
+
+  it("calls Resend API with correct to, subject, html and returns messageId", async () => {
+    const result = await sendEmailNotification(baseNotification);
+
+    expect(mockResendEmailsSend).toHaveBeenCalledOnce();
+    const call = mockResendEmailsSend.mock.calls[0][0];
+    expect(call.to).toBe(baseNotification.recipientEmail);
+    expect(call.subject).toContain(baseNotification.title);
+    expect(call.html).toContain(baseNotification.title);
+    expect(result.messageId).toBe("resend-msg-123");
+    expect(result.success).toBe(true);
+  });
+
+  it("handles Resend API error gracefully — does not throw, logs error", async () => {
+    mockResendEmailsSend.mockResolvedValue({
+      data: null,
+      error: { message: "Invalid API key", name: "invalid_api_key" },
+    });
+
+    const result = await sendEmailNotification(baseNotification);
+
+    expect(result.success).toBe(false);
+    expect(result.error).toBeDefined();
+    // Must NOT throw
+  });
+
+  it("does not send duplicate email for same notification within 5-minute window", async () => {
+    // Simulate a recent outbox entry (within 5 min)
+    const recentlySent = new Date(Date.now() - 2 * 60 * 1000); // 2 min ago
+    mockPrismaNotificationOutboxFindFirst.mockResolvedValue({
+      id: "outbox-001",
+      notificationId: baseNotification.id,
+      channel: "EMAIL",
+      status: "DELIVERED",
+      sentAt: recentlySent,
+    });
+
+    const result = await sendEmailNotification(baseNotification);
+
+    expect(mockResendEmailsSend).not.toHaveBeenCalled();
+    expect(result.skipped).toBe(true);
+    expect(result.reason).toMatch(/duplicate|rate.?limit/i);
+  });
+});
+
+describe("renderEmailTemplate", () => {
+  it("renders correct HTML with notification title, body and actionUrl", () => {
+    const html = renderEmailTemplate({
+      title: baseNotification.title,
+      body: baseNotification.body,
+      actionUrl: baseNotification.actionUrl,
+    });
+
+    expect(html).toContain(baseNotification.title);
+    expect(html).toContain(baseNotification.body);
+    expect(html).toContain(baseNotification.actionUrl);
+    // Should be valid HTML fragment
+    expect(html).toMatch(/<[a-z]/i);
+  });
+});

--- a/src/__tests__/notification-whatsapp.test.ts
+++ b/src/__tests__/notification-whatsapp.test.ts
@@ -1,0 +1,113 @@
+/**
+ * Tests for WhatsApp Notification Delivery Channel (D3-08b)
+ *
+ * Tests:
+ * 1. sendUrgentWhatsApp — sends message via WhatsApp API for priority=URGENT notifications only
+ * 2. sendUrgentWhatsApp — skips non-urgent notifications (returns early, no API call)
+ * 3. WhatsApp message format includes notification title and action URL
+ */
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+// ---------------------------------------------------------------------------
+// Mocks
+// ---------------------------------------------------------------------------
+
+const mockWhatsAppSend = vi.fn();
+
+vi.mock("@/lib/whatsapp-client", () => ({
+  whatsappClient: {
+    sendMessage: mockWhatsAppSend,
+  },
+}));
+
+vi.mock("@/lib/logger", () => ({
+  logger: {
+    error: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+  },
+}));
+
+vi.mock("@/lib/auth", () => ({
+  auth: vi.fn().mockResolvedValue(null),
+}));
+
+// ---------------------------------------------------------------------------
+// Import after mocks are hoisted
+// ---------------------------------------------------------------------------
+
+import { sendUrgentWhatsApp } from "@/lib/notification-channels";
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+const urgentNotification = {
+  id: "notif-urgent-001",
+  title: "Alerta urgente: prazo iminente",
+  body: "O prazo de submissão termina em 30 minutos.",
+  actionUrl: "https://app.useritmo.pt/notifications/notif-urgent-001",
+  recipientPhone: "+351912345678",
+  priority: "URGENT" as const,
+  organizationId: "org-abc",
+};
+
+const normalNotification = {
+  ...urgentNotification,
+  id: "notif-normal-001",
+  title: "Nova atualização disponível",
+  priority: "NORMAL" as const,
+};
+
+const lowNotification = {
+  ...urgentNotification,
+  id: "notif-low-001",
+  title: "Resumo semanal",
+  priority: "LOW" as const,
+};
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("sendUrgentWhatsApp", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockWhatsAppSend.mockResolvedValue({ success: true, messageId: "wa-msg-456" });
+  });
+
+  it("sends WhatsApp message for priority=URGENT notifications", async () => {
+    const result = await sendUrgentWhatsApp(urgentNotification);
+
+    expect(mockWhatsAppSend).toHaveBeenCalledOnce();
+    expect(result.success).toBe(true);
+    expect(result.messageId).toBe("wa-msg-456");
+  });
+
+  it("skips non-urgent notifications — returns early without API call (NORMAL)", async () => {
+    const result = await sendUrgentWhatsApp(normalNotification);
+
+    expect(mockWhatsAppSend).not.toHaveBeenCalled();
+    expect(result.skipped).toBe(true);
+    expect(result.success).toBe(false);
+  });
+
+  it("skips non-urgent notifications — returns early without API call (LOW)", async () => {
+    const result = await sendUrgentWhatsApp(lowNotification);
+
+    expect(mockWhatsAppSend).not.toHaveBeenCalled();
+    expect(result.skipped).toBe(true);
+    expect(result.success).toBe(false);
+  });
+
+  it("WhatsApp message format includes notification title and action URL", async () => {
+    await sendUrgentWhatsApp(urgentNotification);
+
+    expect(mockWhatsAppSend).toHaveBeenCalledOnce();
+    const [to, message] = mockWhatsAppSend.mock.calls[0];
+    expect(to).toBe(urgentNotification.recipientPhone);
+    expect(message).toContain(urgentNotification.title);
+    expect(message).toContain(urgentNotification.actionUrl);
+  });
+});

--- a/src/lib/notification-channels.ts
+++ b/src/lib/notification-channels.ts
@@ -1,0 +1,75 @@
+/**
+ * Notification Delivery Channels (D3-08b)
+ *
+ * Stub — implementation pending.
+ * Tests in src/__tests__/notification-email.test.ts and notification-whatsapp.test.ts
+ * are RED-phase TDD covering this module.
+ */
+
+export interface EmailNotificationInput {
+  id: string;
+  title: string;
+  body: string;
+  actionUrl: string;
+  recipientEmail: string;
+  organizationId: string;
+}
+
+export interface EmailNotificationResult {
+  success: boolean;
+  messageId?: string;
+  error?: string;
+  skipped?: boolean;
+  reason?: string;
+}
+
+export interface WhatsAppNotificationInput {
+  id: string;
+  title: string;
+  body: string;
+  actionUrl: string;
+  recipientPhone: string;
+  priority: "URGENT" | "NORMAL" | "LOW";
+  organizationId: string;
+}
+
+export interface WhatsAppNotificationResult {
+  success: boolean;
+  messageId?: string;
+  error?: string;
+  skipped?: boolean;
+  reason?: string;
+}
+
+export interface EmailTemplateInput {
+  title: string;
+  body: string;
+  actionUrl: string;
+}
+
+/**
+ * Send an email notification via Resend.
+ * Includes rate-limit dedup: skips if same notification was sent within 5 minutes.
+ */
+export async function sendEmailNotification(
+  _input: EmailNotificationInput
+): Promise<EmailNotificationResult> {
+  throw new Error("Not implemented");
+}
+
+/**
+ * Send a WhatsApp message for URGENT priority notifications only.
+ * Non-urgent notifications are skipped.
+ */
+export async function sendUrgentWhatsApp(
+  _input: WhatsAppNotificationInput
+): Promise<WhatsAppNotificationResult> {
+  throw new Error("Not implemented");
+}
+
+/**
+ * Render an HTML email template for a notification.
+ */
+export function renderEmailTemplate(_input: EmailTemplateInput): string {
+  throw new Error("Not implemented");
+}


### PR DESCRIPTION
## Summary
- `notification-email.test.ts`: 4 tests for `sendEmailNotification` — Resend API call verification (to/subject/html), error handling (no throw), `renderEmailTemplate` HTML rendering, rate-limit dedup within 5-min window
- `notification-whatsapp.test.ts`: 4 tests for `sendUrgentWhatsApp` — URGENT-only routing, non-urgent skip (NORMAL + LOW), message format (title + actionUrl)

**RED-phase TDD** — implementation (`@/lib/notification-channels`) is pending next sprint task.

Mocks: `resend`, `@/lib/whatsapp-client`, `@/lib/prisma` (notificationOutbox), `@/lib/logger`, `@/lib/auth`

## Test plan
- [ ] Tests are intentionally RED (implementation not yet created)
- [ ] Lint ✅ (0 errors)
- [ ] Build ✅ (CI handles typecheck)

## Preview URL
N/A — test-only PR, no UI changes

Task: gov-1775091686675-8mrpkg